### PR TITLE
fix(logging): log message format in request handling

### DIFF
--- a/internal/handlers/handler/processor.go
+++ b/internal/handlers/handler/processor.go
@@ -204,7 +204,12 @@ func (p *Handler) handle(ctx *fh.RequestCtx) {
 		}
 
 		if r.Code < 200 || r.Code >= 300 {
-			p.Log.Info("src=%s req_id=%s HTTP code %d (%s)", ctx.RemoteAddr(), reqID, r.Code, string(r.Body))
+			p.Log.Info("handling request",
+				"src", ctx.RemoteAddr(),
+				"req_id", reqID,
+				"code", r.Code,
+				"body", string(r.Body),
+			)
 		}
 
 		if r.Code > code {


### PR DESCRIPTION
I've run into panics caused by logr basically immediately once a request comes in to the proxy. As far as I've seen logr doesn't support format-string style logging, so this PR updates the one offending call to logr to also use structured logging.

No more panics after this PR.