### PR TITLE
fix(marshal): processors should use snappy encoding in the end

### DIFF
--- a/internal/handlers/processors/cortex/processor.go
+++ b/internal/handlers/processors/cortex/processor.go
@@ -137,7 +137,7 @@ func createTenantRequests(h *handler.Handler, req *prompb.WriteRequest) (r map[s
 			return true
 		}
 
-		buf, err := proto.Marshal(writeReq)
+		buf, err := marshal(writeReq)
 		if err != nil {
 			h.Log.Error(err, "failed to marshal request")
 

--- a/internal/handlers/processors/loki/processor.go
+++ b/internal/handlers/processors/loki/processor.go
@@ -134,7 +134,7 @@ func createTenantRequests(h *handler.Handler, req *logproto.PushRequest) (r map[
 			return true
 		}
 
-		buf, err := proto.Marshal(writeReq)
+		buf, err := marshal(writeReq)
 		if err != nil {
 			h.Log.Error(err, "failed to marshal request")
 


### PR DESCRIPTION
This pull request makes a small but important change to the way requests are marshaled in both the Cortex and Loki processors. The current code is simply using the protobuf marshaller, which doesn't work for me, since both Mimir as well as Loki are complaining that incoming requests are supposed to be snappy encoded.