### PR TITLE
fix(controller): actually start the namespace controller

### DIFF
--- a/cmd/cortex-proxy/main.go
+++ b/cmd/cortex-proxy/main.go
@@ -98,16 +98,22 @@ func main() {
 	store := stores.NewNamespaceStore()
 	metricsRecorder := metrics.MustMakeRecorder("cortex")
 
-	tenants := &namespace.StoreController{
+	namespaces := &namespace.StoreController{
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Config:  cfg,
 		Metrics: metricsRecorder,
 		Store:   store,
+		Log:     ctrl.Log.WithName("namespace-controller"),
 	}
 
-	if err = tenants.Init(ctx, directClient); err != nil {
+	if err = namespaces.Init(ctx, directClient); err != nil {
 		setupLog.Error(err, "unable to initialize settings")
+		os.Exit(1)
+	}
+
+	if err = namespaces.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to set up namespace controller")
 		os.Exit(1)
 	}
 

--- a/cmd/loki-proxy/main.go
+++ b/cmd/loki-proxy/main.go
@@ -104,10 +104,16 @@ func main() {
 		Config:  cfg,
 		Metrics: metricsRecorder,
 		Store:   store,
+		Log:     ctrl.Log.WithName("namespace-controller"),
 	}
 
 	if err = namespaces.Init(ctx, directClient); err != nil {
 		setupLog.Error(err, "unable to initialize settings")
+		os.Exit(1)
+	}
+
+	if err = namespaces.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to set up namespace controller")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Hey there!

Maybe I'm mistaken, but while giving the proxy a try, I've noticed that it does not take changes to namespaces / their tenant annotation into account while the proxy is running. 

Looking into the code and running some debugging, that's caused by the fact that while the namespace controller is being created and it's `Init` func ran once to get an initial list of namespaces into the system, the controller process itself is never started, so namespace changes are basically ignored.

This PR fixes that.